### PR TITLE
Moved away from horstbaerbel's repo. Used ubuntu:rolling so that we g…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
+# This is largely copied from https://github.com/HorstBaerbel/ccpp-cmake-build-and-test
+# But, we just get clang-format-12 from ubuntu-rolling (ubuntu:latest currently 20.04 doesn't have it).
 FROM ubuntu:rolling
 
 WORKDIR /
 
+# Timezone setup might be needed in order for packages to install properly.
 ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM horstbaerbel/ccpp-cmake-build-and-test:1.0
+FROM ubuntu:rolling
+
+WORKDIR /
+
+ENV TZ=Europe/Berlin
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt update
+RUN apt -y dist-upgrade
+RUN apt -y install clang-format-12
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100
+
+RUN apt -y autoclean
+RUN apt -y clean
+RUN rm -rf /var/lib/apt/lists/*
 
 LABEL "com.github.actions.name"="action-clang-format"
 LABEL "com.github.actions.description"="Run clang-format on source directory"


### PR DESCRIPTION
…et the latest clang-format-12 as ubuntu:latest doesn't have it.

# Why

All render-node devs seem to have IDEs setup to use clang-format-12.

So, inevitably, what happens is that IDEs format code differently compared to what the github action based on this repo expects. This can waste time not to mention become annoying and frustrating.

# What

The https://github.com/HorstBaerbel/ccpp-cmake-build-and-test docker image upon which https://github.com/HorstBaerbel/action-clang-format (and us) are based on still hasn't moved to clang-format-12. That is not available with ubuntu-latest, which is based on 20:04 (current LTS).

So, I've elected to use the ubuntu:rolling image which is every release os Ubuntu. We also don't need other tools, so those haven't been included.

See https://hub.docker.com/_/ubuntu
